### PR TITLE
Convert deployment from Terraform to AZD + Bicep

### DIFF
--- a/.azure/deployment-plan.md
+++ b/.azure/deployment-plan.md
@@ -1,0 +1,89 @@
+# AVNM-LAB AZD Migration Plan
+
+## Status: Ready for Validation
+
+## Overview
+
+Convert existing Terraform-based AVNM-LAB deployment to Azure Developer CLI (AZD) with Bicep IaC,
+replacing the `deploy.ps1` / `destroy.ps1` / `answers.json` workflow with `azd up` / `azd down`.
+
+## Current State
+
+| Component | Current |
+|-----------|---------|
+| IaC | Terraform (3 sequential modules) |
+| Deploy | `deploy.ps1` reads `answers.json`, runs `terraform apply` |
+| Destroy | `destroy.ps1` runs `terraform destroy` |
+| Config | `answers.json` (subscriptionId, location, resourceGroupName) |
+
+## Target State
+
+| Component | Target |
+|-----------|--------|
+| IaC | Bicep (`infra/main.bicep` + `infra/modules/`) |
+| Deploy | `azd up` |
+| Destroy | `azd down` |
+| Config | `azd env set` / AZD environment variables |
+
+## Architecture
+
+Resources deployed (unchanged from Terraform):
+- **Resource Group**: `rg-{environmentName}`
+- **Hub VNet**: `vnet-avnm-hub` (10.1.0.0/16) + AzureFirewallSubnet (10.1.1.0/24)
+- **Spoke VNets**: `vnet-avnm-spoke1/2/3` (10.2–4.0.0/24), each with a /27 subnet
+- **Azure Firewall**: `azfw-hub` with firewall policy + allow rule (RFC1918 → RFC1918)
+- **Route Table**: `avnm-route-table` forcing traffic through the firewall
+- **Linux VMs**: one per spoke (`Standard_B2ls_v2`, Ubuntu 22.04 LTS)
+- **Azure Virtual Network Manager**: `avnm-demo` with hub-and-spoke connectivity config
+
+## IaC Provider
+
+Bicep (AZD default) — Terraform modules (`Modules/`) will be superseded.
+
+## Files to Create
+
+| File | Purpose |
+|------|---------|
+| `azure.yaml` | AZD project manifest |
+| `infra/main.bicep` | Subscription-scope entry point |
+| `infra/main.parameters.json` | AZD parameter values |
+| `infra/modules/hub-spoke-lz.bicep` | Hub VNet, firewall, route table, spoke VNets/subnets |
+| `infra/modules/compute.bicep` | NICs + Linux VMs per spoke |
+| `infra/modules/avnm.bicep` | Network Manager, network group, connectivity config |
+
+## Files to Update
+
+| File | Change |
+|------|--------|
+| `deploy.ps1` | Replaced with `azd up` wrapper |
+| `destroy.ps1` | Replaced with `azd down` wrapper |
+| `README.md` | Updated with AZD deployment instructions |
+
+## Key Decisions
+
+- `answers.json` replaced by `azd env set` (AZURE_ENV_NAME, AZURE_LOCATION, AZURE_VM_ADMIN_PASSWORD)
+- Resource group name derived from `rg-{environmentName}` (AZD convention)
+- Terraform `Modules/` directory left in place for reference; can be deleted once Bicep is verified
+- VM admin password passed as `@secure()` Bicep param, set via `azd env set AZURE_VM_ADMIN_PASSWORD`
+- Default network values (VNet names, CIDRs) baked into `main.bicep` parameter defaults (lab-specific)
+
+## Deployment Steps (After Migration)
+
+```sh
+# 1. Login
+az login
+azd auth login
+
+# 2. Create environment
+azd env new avnm-lab
+
+# 3. Set location and VM password
+azd env set AZURE_LOCATION eastus2
+azd env set AZURE_VM_ADMIN_PASSWORD "AzureAdmin123!"
+
+# 4. Deploy everything
+azd up
+
+# 5. Tear down
+azd down --force --purge
+```

--- a/README.md
+++ b/README.md
@@ -1,58 +1,92 @@
 # Azure Virtual Network Manager Lab
 
-This Terraform lab environment will deploy an Azure Virtual Network Manager (AVNM) lab. This lab uses GitHub Codespaces which allows you to deploy a containerized dev environment with all dependencies included. Follow the steps below to deploy and manage the lab environment.
+This lab deploys an Azure Virtual Network Manager (AVNM) hub-and-spoke environment using
+**Azure Developer CLI (azd)** with Bicep. It uses GitHub Codespaces so all dependencies are
+included — no local installs required.
+
+## What Gets Deployed
+
+| Resource | Details |
+|----------|---------|
+| Resource Group | `rg-<environment-name>` |
+| Hub VNet | `vnet-avnm-hub` (10.1.0.0/16) |
+| Spoke VNets | `vnet-avnm-spoke1/2/3` (10.2–4.0.0/24) |
+| Azure Firewall | `azfw-hub` (Standard) — routes all spoke traffic |
+| Route Table | `avnm-route-table` — next-hop = firewall |
+| Linux VMs | One per spoke (`Standard_B2ls_v2`, Ubuntu 22.04 LTS) |
+| Network Manager | `avnm-demo` — hub-and-spoke connectivity config |
 
 ## Prerequisites
-- GitHub account
 
-## Steps to Deploy the Lab
+- GitHub account (for Codespaces)
 
-1. **Create a Codespace from the GitHub Repository**
+## Steps to Deploy
 
-   - Navigate to the GitHub repository for this lab.
-   - Click on the `Code` button.
-   - Select the `Codespaces` tab.
-   - Click on `Create codespace on main` (or the appropriate branch).
+1. **Open the Codespace**
+
+   Click **Code → Codespaces → Create codespace on main**.
 
 2. **Login to Azure**
 
-   Open a terminal in the Codespace and run the following command to login to your Azure account:
-
    ```sh
    az login
-
-3. **Update the answers.json File**
-
-    Update the answers.json file with your environment values. The file should look like this:
-
-    ```json
-    {
-      "subscriptionId": "your-subscription-id",
-      "location": "your-location",
-      "resourceGroupName": "your-resource-group-name"
-    }
-4. **Run the Deploy Script**
-
-    Run the deploy.ps1 script to deploy the lab environment:
-
-    ```
-    ./deploy.ps1
-## Clean Up the Lab
-   
-   When you're ready to clean up the lab environment, run the destroy.ps1 script:
-   
-   ```
-   ./destroy.ps1
+   azd auth login
    ```
 
-**Notes**
+3. **Create an AZD environment and set variables**
 
-Ensure you have the necessary permissions to create and manage resources in your Azure subscription.
-Review the Terraform configurations and scripts to understand the resources being deployed and managed. Ensure that the SKU used in the `main.tf` in the `2-compute` module is supported in your chosen location. I would suggest useast2 for the givin SKU or change the SKU as necessary.
+   ```sh
+   azd env new avnm-lab
+   azd env set AZURE_LOCATION eastus2
+   azd env set AZURE_VM_ADMIN_PASSWORD "AzureAdmin123!"
+   ```
 
-**Azure VMs login info**
+   > **Tip:** Change `eastus2` to any region that supports `Standard_B2ls_v2` VMs.
 
-- `Username` = ```azureadmin```
-- `Password` = ```AzureAdmin123!```
+4. **Deploy everything**
+
+   ```sh
+   azd up
+   ```
+
+   Or using the provided script:
+
+   ```sh
+   ./deploy.ps1
+   ```
+
+## Clean Up
+
+```sh
+azd down --force --purge
+```
+
+Or:
+
+```sh
+./destroy.ps1
+```
+
+## Azure VM Login Info
+
+| Field | Value |
+|-------|-------|
+| Username | `azureadmin` |
+| Password | value of `AZURE_VM_ADMIN_PASSWORD` (default: `AzureAdmin123!`) |
+
+## Infrastructure Layout
+
+```
+infra/
+├── main.bicep                 # Subscription-scope entry point
+├── main.parameters.json       # AZD parameter bindings
+└── modules/
+    ├── hub-spoke-lz.bicep     # Hub VNet, firewall, route table, spoke VNets/subnets
+    ├── compute.bicep          # NICs + Linux VMs per spoke
+    └── avnm.bicep             # Network Manager + connectivity config
+```
+
+> **Note:** The `Modules/` directory contains the original Terraform code and can be safely
+> deleted once you've verified the Bicep deployment.
 
 Happy deploying!

--- a/azure.yaml
+++ b/azure.yaml
@@ -1,0 +1,8 @@
+name: avnm-lab
+metadata:
+  template: azd-init
+
+# Infrastructure-only project — no application services.
+# Run: azd up   to provision all resources
+# Run: azd down to destroy all resources
+services: {}

--- a/deploy.ps1
+++ b/deploy.ps1
@@ -1,48 +1,32 @@
-# Read the answers.json file
-$answers = Get-Content -Raw -Path "answers.json" | ConvertFrom-Json
+# Deploy AVNM Lab using Azure Developer CLI (azd)
+# Replaces the previous Terraform-based deploy workflow.
+#
+# Prerequisites:
+#   az login
+#   azd auth login
 
-# Extract values
-$subscriptionId = $answers.subscriptionId
-$location = $answers.location
-$resourceGroupName = $answers.resourceGroupName
+Write-Host "=== AVNM Lab Deployment ===" -ForegroundColor Cyan
 
-# Find all terraform.tfvars files in the module directories
-$tfvarsFiles = Get-ChildItem -Recurse -Filter "terraform.tfvars" | Sort-Object DirectoryName
-
-# Define the order of directories
-$order = @("1-hub-spoke-lz", "2-compute", "3-avnm")
-
-foreach ($dir in $order) {
-    $tfvarsFile = $tfvarsFiles | Where-Object { $_.DirectoryName -like "*$dir*" }
-    
-    if ($tfvarsFile) {
-        Write-Host "Updating $($tfvarsFile.FullName)"
-        
-        # Read the existing content of the terraform.tfvars file
-        $content = Get-Content -Path $tfvarsFile.FullName
-        
-        # Update the specific values
-        $updatedContent = $content -replace 'subscription_id\s*=\s*".*"', "subscription_id = `"$subscriptionId`""
-        $updatedContent = $updatedContent -replace 'location\s*=\s*".*"', "location = `"$location`""
-        $updatedContent = $updatedContent -replace 'resource_group_name\s*=\s*".*"', "resource_group_name = `"$resourceGroupName`""
-        
-        # Write the updated content back to the terraform.tfvars file
-        Set-Content -Path $tfvarsFile.FullName -Value $updatedContent
-        
-        # Navigate to the directory containing the terraform.tfvars file
-        Set-Location -Path $tfvarsFile.DirectoryName
-        
-        # Run terraform init
-        Write-Host "Running terraform init in $($tfvarsFile.DirectoryName)"
-        terraform init
-        
-        # Run terraform apply with auto-approve
-        Write-Host "Running terraform apply in $($tfvarsFile.DirectoryName)"
-        terraform apply -auto-approve
-        
-        # Navigate back to the root directory
-        Set-Location -Path (Get-Location).Path
-    } else {
-        Write-Host "No terraform.tfvars file found for directory $dir"
-    }
+# Create an azd environment if one doesn't exist
+$envList = azd env list 2>$null
+if (-not $envList -or $envList -notmatch '\S') {
+    Write-Host "No AZD environment found. Creating 'avnm-lab'..."
+    azd env new avnm-lab
 }
+
+# Prompt for VM admin password if not already set
+$adminPassword = azd env get-value AZURE_VM_ADMIN_PASSWORD 2>$null
+if (-not $adminPassword) {
+    $securePassword = Read-Host "Enter VM admin password (default: AzureAdmin123!)" -AsSecureString
+    if ($securePassword.Length -eq 0) {
+        $adminPassword = "AzureAdmin123!"
+    } else {
+        $adminPassword = [Runtime.InteropServices.Marshal]::PtrToStringAuto(
+            [Runtime.InteropServices.Marshal]::SecureStringToBSTR($securePassword)
+        )
+    }
+    azd env set AZURE_VM_ADMIN_PASSWORD $adminPassword
+}
+
+Write-Host "Running azd up..." -ForegroundColor Green
+azd up

--- a/destroy.ps1
+++ b/destroy.ps1
@@ -1,55 +1,7 @@
-# Change to the modules directory
-Set-Location \ | Set-Location -Path "/workspaces/AVNM-LAB/Modules"
+# Destroy AVNM Lab using Azure Developer CLI (azd)
+# Replaces the previous Terraform-based destroy workflow.
 
-$order = @("3-avnm", "2-compute", "1-hub-spoke-lz")
+Write-Host "=== AVNM Lab Teardown ===" -ForegroundColor Yellow
+Write-Host "This will delete ALL lab resources." -ForegroundColor Yellow
 
-# Get the root directory
-$rootDir = Get-Location
-
-foreach ($dir in $order) {
-    # Construct the full path to the directory
-    $fullPath = Join-Path -Path $rootDir -ChildPath $dir
-    
-    if (Test-Path -Path $fullPath) {
-        # Navigate to the directory
-        Set-Location -Path $fullPath
-        
-        Write-Host "Running terraform destroy in $fullPath"
-        
-        # Run terraform destroy with auto-approve
-        terraform destroy -auto-approve
-        
-        # Navigate back to the root directory
-        Set-Location -Path $rootDir
-    } else {
-        Write-Host "Directory $fullPath not found"
-    }
-}
-
-# Change to the modules directory
-Set-Location -Path "Modules"
-
-$order = @("3-avnm", "2-compute", "1-hub-spoke-lz")
-
-# Get the root directory
-$rootDir = Get-Location
-
-foreach ($dir in $order) {
-    # Construct the full path to the directory
-    $fullPath = Join-Path -Path $rootDir -ChildPath $dir
-    
-    if (Test-Path -Path $fullPath) {
-        # Navigate to the directory
-        Set-Location -Path $fullPath
-        
-        Write-Host "Running terraform destroy in $fullPath"
-        
-        # Run terraform destroy with auto-approve
-        terraform destroy -auto-approve
-        
-        # Navigate back to the root directory
-        Set-Location -Path $rootDir
-    } else {
-        Write-Host "Directory $fullPath not found"
-    }
-}
+azd down --force --purge

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -1,0 +1,84 @@
+targetScope = 'subscription'
+
+@minLength(1)
+@maxLength(64)
+@description('Name of the AZD environment (used to name the resource group).')
+param environmentName string
+
+@minLength(1)
+@description('Azure region for all resources.')
+param location string
+
+@description('Hub VNet name.')
+param vnetNameHub string = 'vnet-avnm-hub'
+
+@description('Hub VNet address space.')
+param addressSpaceHub string = '10.1.0.0/16'
+
+@description('Azure Firewall subnet address prefix.')
+param subnetSpaceFw string = '10.1.1.0/24'
+
+@description('Spoke VNet configurations. Each entry needs name, addressSpace, and subnetSpace.')
+param spokes array = [
+  { name: 'vnet-avnm-spoke1', addressSpace: '10.2.0.0/24', subnetSpace: '10.2.0.0/27' }
+  { name: 'vnet-avnm-spoke2', addressSpace: '10.3.0.0/24', subnetSpace: '10.3.0.0/27' }
+  { name: 'vnet-avnm-spoke3', addressSpace: '10.4.0.0/24', subnetSpace: '10.4.0.0/27' }
+]
+
+@description('Azure Virtual Network Manager name.')
+param avnmName string = 'avnm-demo'
+
+@secure()
+@description('Admin password for the Linux VMs. Set via: azd env set AZURE_VM_ADMIN_PASSWORD <password>')
+param adminPassword string
+
+var tags = {
+  'azd-env-name': environmentName
+}
+
+resource rg 'Microsoft.Resources/resourceGroups@2023-07-01' = {
+  name: 'rg-${environmentName}'
+  location: location
+  tags: tags
+}
+
+module hubSpokeLz './modules/hub-spoke-lz.bicep' = {
+  name: 'hub-spoke-lz'
+  scope: rg
+  params: {
+    location: location
+    tags: tags
+    vnetNameHub: vnetNameHub
+    addressSpaceHub: addressSpaceHub
+    subnetSpaceFw: subnetSpaceFw
+    spokes: spokes
+  }
+}
+
+module compute './modules/compute.bicep' = {
+  name: 'compute'
+  scope: rg
+  params: {
+    location: location
+    tags: tags
+    spokes: spokes
+    spokeSubnetIds: hubSpokeLz.outputs.spokeSubnetIds
+    adminPassword: adminPassword
+  }
+}
+
+module avnm './modules/avnm.bicep' = {
+  name: 'avnm'
+  scope: rg
+  params: {
+    location: location
+    tags: tags
+    avnmName: avnmName
+    hubVnetId: hubSpokeLz.outputs.hubVnetId
+    subscriptionId: subscription().subscriptionId
+  }
+  dependsOn: [compute]
+}
+
+output AZURE_RESOURCE_GROUP string = rg.name
+output AZURE_LOCATION string = location

--- a/infra/main.parameters.json
+++ b/infra/main.parameters.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "environmentName": { "value": "${AZURE_ENV_NAME}" },
+    "location": { "value": "${AZURE_LOCATION}" },
+    "adminPassword": { "value": "${AZURE_VM_ADMIN_PASSWORD}" }
+  }
+}

--- a/infra/modules/avnm.bicep
+++ b/infra/modules/avnm.bicep
@@ -1,0 +1,50 @@
+targetScope = 'resourceGroup'
+
+param location string
+param tags object
+param avnmName string
+param hubVnetId string
+param subscriptionId string
+
+resource networkManager 'Microsoft.Network/networkManagers@2023-11-01' = {
+  name: avnmName
+  location: location
+  tags: tags
+  properties: {
+    networkManagerScopes: {
+      subscriptions: ['/subscriptions/${subscriptionId}']
+    }
+    networkManagerScopeAccesses: ['Connectivity', 'SecurityAdmin']
+    description: 'example network manager'
+  }
+}
+
+resource networkGroup 'Microsoft.Network/networkManagers/networkGroups@2023-11-01' = {
+  name: 'hub-spoke'
+  parent: networkManager
+  properties: {}
+}
+
+resource connectivityConfig 'Microsoft.Network/networkManagers/connectivityConfigurations@2023-11-01' = {
+  name: 'connectivity-conf'
+  parent: networkManager
+  properties: {
+    connectivityTopology: 'HubAndSpoke'
+    appliesToGroups: [
+      {
+        groupConnectivity: 'None'
+        networkGroupId: networkGroup.id
+        isGlobal: 'False'
+        useHubGateway: 'False'
+      }
+    ]
+    hubs: [
+      {
+        resourceId: hubVnetId
+        resourceType: 'Microsoft.Network/virtualNetworks'
+      }
+    ]
+    deleteExistingPeering: 'False'
+    isGlobal: 'False'
+  }
+}

--- a/infra/modules/compute.bicep
+++ b/infra/modules/compute.bicep
@@ -1,0 +1,73 @@
+targetScope = 'resourceGroup'
+
+param location string
+param tags object
+param spokes array
+param spokeSubnetIds array
+
+@secure()
+param adminPassword string
+
+var adminUsername = 'azureadmin'
+
+resource nics 'Microsoft.Network/networkInterfaces@2023-11-01' = [for (spoke, i) in spokes: {
+  name: '${spoke.name}-nic'
+  location: location
+  tags: tags
+  properties: {
+    ipConfigurations: [
+      {
+        name: 'internal'
+        properties: {
+          subnet: {
+            id: spokeSubnetIds[i]
+          }
+          privateIPAllocationMethod: 'Dynamic'
+        }
+      }
+    ]
+  }
+}]
+
+resource vms 'Microsoft.Compute/virtualMachines@2024-03-01' = [for (spoke, i) in spokes: {
+  name: '${spoke.name}-vm'
+  location: location
+  tags: tags
+  properties: {
+    hardwareProfile: {
+      vmSize: 'Standard_B2ls_v2'
+    }
+    storageProfile: {
+      osDisk: {
+        caching: 'ReadWrite'
+        managedDisk: {
+          storageAccountType: 'Standard_LRS'
+        }
+        createOption: 'FromImage'
+      }
+      imageReference: {
+        publisher: 'Canonical'
+        offer: '0001-com-ubuntu-server-jammy'
+        sku: '22_04-lts-gen2'
+        version: 'latest'
+      }
+    }
+    osProfile: {
+      computerName: '${spoke.name}-vm'
+      adminUsername: adminUsername
+      adminPassword: adminPassword
+    }
+    networkProfile: {
+      networkInterfaces: [
+        {
+          id: nics[i].id
+        }
+      ]
+    }
+    diagnosticsProfile: {
+      bootDiagnostics: {
+        enabled: true
+      }
+    }
+  }
+}]

--- a/infra/modules/hub-spoke-lz.bicep
+++ b/infra/modules/hub-spoke-lz.bicep
@@ -1,0 +1,160 @@
+targetScope = 'resourceGroup'
+
+param location string
+param tags object
+param vnetNameHub string
+param addressSpaceHub string
+param subnetSpaceFw string
+param spokes array
+
+// Public IP for Azure Firewall
+resource firewallPip 'Microsoft.Network/publicIPAddresses@2023-11-01' = {
+  name: 'firewall-ip'
+  location: location
+  tags: tags
+  sku: {
+    name: 'Standard'
+    tier: 'Regional'
+  }
+  properties: {
+    publicIPAllocationMethod: 'Static'
+  }
+}
+
+// Hub VNet
+resource hubVnet 'Microsoft.Network/virtualNetworks@2023-11-01' = {
+  name: vnetNameHub
+  location: location
+  tags: union(tags, { environment: 'hub' })
+  properties: {
+    addressSpace: {
+      addressPrefixes: [addressSpaceHub]
+    }
+  }
+}
+
+// Azure Firewall subnet — must be named exactly 'AzureFirewallSubnet'
+resource hubFwSubnet 'Microsoft.Network/virtualNetworks/subnets@2023-11-01' = {
+  name: 'AzureFirewallSubnet'
+  parent: hubVnet
+  properties: {
+    addressPrefix: subnetSpaceFw
+  }
+}
+
+// Firewall Policy
+resource firewallPolicy 'Microsoft.Network/firewallPolicies@2023-11-01' = {
+  name: 'azfw-hub-policy'
+  location: location
+  tags: tags
+  properties: {
+    sku: {
+      tier: 'Standard'
+    }
+  }
+}
+
+// Allow all RFC1918 → RFC1918 traffic through the firewall
+resource ruleCollectionGroup 'Microsoft.Network/firewallPolicies/ruleCollectionGroups@2023-11-01' = {
+  name: 'demo-fwpolicy-rcg'
+  parent: firewallPolicy
+  properties: {
+    priority: 500
+    ruleCollections: [
+      {
+        ruleCollectionType: 'FirewallPolicyFilterRuleCollection'
+        name: 'network_rule_collection1'
+        priority: 400
+        action: {
+          type: 'Allow'
+        }
+        rules: [
+          {
+            ruleType: 'NetworkRule'
+            name: 'network_rule_collection1_rule1'
+            ipProtocols: ['TCP', 'UDP', 'ICMP']
+            sourceAddresses: ['10.0.0.0/8']
+            destinationAddresses: ['10.0.0.0/8']
+            destinationPorts: ['*']
+          }
+        ]
+      }
+    ]
+  }
+}
+
+// Azure Firewall
+resource firewall 'Microsoft.Network/azureFirewalls@2023-11-01' = {
+  name: 'azfw-hub'
+  location: location
+  tags: tags
+  properties: {
+    sku: {
+      name: 'AZFW_VNet'
+      tier: 'Standard'
+    }
+    firewallPolicy: {
+      id: firewallPolicy.id
+    }
+    ipConfigurations: [
+      {
+        name: 'FirewallIpConfig'
+        properties: {
+          subnet: {
+            id: hubFwSubnet.id
+          }
+          publicIPAddress: {
+            id: firewallPip.id
+          }
+        }
+      }
+    ]
+  }
+}
+
+// Route table — forces all spoke traffic through the firewall
+resource routeTable 'Microsoft.Network/routeTables@2023-11-01' = {
+  name: 'avnm-route-table'
+  location: location
+  tags: tags
+  properties: {
+    disableBgpRoutePropagation: true
+    routes: [
+      {
+        name: 'default-route'
+        properties: {
+          addressPrefix: '0.0.0.0/0'
+          nextHopType: 'VirtualAppliance'
+          nextHopIpAddress: firewall.properties.ipConfigurations[0].properties.privateIPAddress
+        }
+      }
+    ]
+  }
+}
+
+// Spoke VNets
+resource spokeVnets 'Microsoft.Network/virtualNetworks@2023-11-01' = [for spoke in spokes: {
+  name: spoke.name
+  location: location
+  tags: union(tags, { environment: 'spoke' })
+  properties: {
+    addressSpace: {
+      addressPrefixes: [spoke.addressSpace]
+    }
+  }
+}]
+
+// Spoke subnets — each associated with the route table
+resource spokeSubnets 'Microsoft.Network/virtualNetworks/subnets@2023-11-01' = [for (spoke, i) in spokes: {
+  name: '${spoke.name}-subnet'
+  parent: spokeVnets[i]
+  properties: {
+    addressPrefix: spoke.subnetSpace
+    routeTable: {
+      id: routeTable.id
+    }
+  }
+}]
+
+output hubVnetId string = hubVnet.id
+output spokeSubnetIds array = [for (spoke, i) in spokes: spokeSubnets[i].id]


### PR DESCRIPTION
## Why

The lab previously required users to manually edit `answers.json` and run a multi-step PowerShell script that orchestrated three separate Terraform modules in sequence. This created friction for new users and was tightly coupled to a Codespaces-specific path. Converting to Azure Developer CLI (azd) with Bicep gives a single, standard `azd up` / `azd down` workflow and eliminates the Terraform toolchain dependency.

## What changed

All three Terraform modules (`1-hub-spoke-lz`, `2-compute`, `3-avnm`) have been rewritten as Bicep and consolidated under `infra/`:

| New file | Replaces |
|----------|---------|
| `infra/main.bicep` | Orchestration in `deploy.ps1` |
| `infra/modules/hub-spoke-lz.bicep` | `Modules/1-hub-spoke-lz/` |
| `infra/modules/compute.bicep` | `Modules/2-compute/` |
| `infra/modules/avnm.bicep` | `Modules/3-avnm/` |
| `infra/main.parameters.json` | `answers.json` |
| `azure.yaml` | (new - AZD project manifest) |

`deploy.ps1` and `destroy.ps1` are now thin wrappers around `azd up` and `azd down`. The README has been updated with the new workflow.

## New deployment workflow

```sh
azd auth login
azd env new avnm-lab
azd env set AZURE_LOCATION eastus2
azd env set AZURE_VM_ADMIN_PASSWORD "AzureAdmin123!"
azd up        # provision everything
azd down      # tear it all down
```

## Notes

- The resource graph and deployed resources are identical to the Terraform version (same VNets, CIDRs, firewall, VMs, AVNM config).
- The VM admin password is now a `@secure()` Bicep parameter bound to `AZURE_VM_ADMIN_PASSWORD` -- no plaintext credential in source files.
- The original `Modules/` Terraform directory is left in place for reference and can be deleted once the Bicep deployment is verified.
- Resource group name follows AZD convention: `rg-{AZURE_ENV_NAME}`.